### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify-standard-library-dependencies.yml
+++ b/.github/workflows/verify-standard-library-dependencies.yml
@@ -1,4 +1,6 @@
 name: Verify Standard Library Dependencies
+permissions:
+  contents: read
 
 # Run this workflow every time the "supported_codeql_configs.json" file or a "qlpack.yml" file is changed
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/AndresMaqueo/codeql-coding-standards/security/code-scanning/25](https://github.com/AndresMaqueo/codeql-coding-standards/security/code-scanning/25)

To fix the problem, we should add a `permissions:` block at the top level of the workflow file. This block should specify only the required privileges, generally starting with minimal permissions such as `contents: read`, which allows the jobs to check out code, read files, and perform CI steps, but not to push, open PRs, or alter repository state. We add the block immediately under the workflow name (before the `on:` trigger). No additional imports or code changes are needed elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
